### PR TITLE
Scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,6 @@ function load($){
 	`<div class=${$}__element_modificator>`
 //	<div class=block__element_modificator>
 ```
-### $.appendChild(InnerHTML)
-- overload this.appendChild(InnerHTML:string):HtmlElement|HtmlElement[]
-- can append multiple, in this case return array of child nodes
-### $.removeChild(HtmlElement)
-- just alias for this.removeChild
 ### $.log(tabs:Number)
 - can be used for log recursive tree of virtual element binded scope (children & methods)
 # Nested Components
@@ -86,5 +81,27 @@ You can force config const eventTypes to extend library by other native DOM even
 ```
 - click will call $.method of .sub element from subcomponent.htm &lt;script&gt; section
 # TODO Roadmap
-- fetch cache
-- bind arguments extend
+## features
+- $('className[]') return childs[], :fisrt/last-of-type converts to [0/-1] child
+- $('className') return :fisrt-of-type
+- reuse $('className[]') in removeChild
+- bind with arguments (child constructor standart)
+- validate child by interface above _class
+## fixes
+- element.removeChild(childElement) destruct $(childElement)
+- nested child bind infinite chain length (for now just self children)
+## optimization
+- fetch cache (for now just browser/server chache somehow)
+
+## moot features
+```js
+f[Symbol.toStringTag] //detect async function binding (and then update)
+f=>Promise[] //runtime detect Promise or Promise[] for update when resolve
+
+$('beforeend',`<div _class=component></div>`) insertAdjacentHTML and $.update shortcut
+
+$({}) //one pass set component scope
+$('<div _class=component></div>') //capture exact load targets
+_class=component(args) //component constructor args
+_class=_{modificator}:component //argument reactive bind
+```

--- a/README.md
+++ b/README.md
@@ -47,15 +47,49 @@ function load($){
 - function runs when DOM is loaded
 - this will applyed to rootElement ( .foo in example)
 - $ argument pass the patched query selector functionality and above component scope
+### onload / onmount / dismount
+- onload function is virtual that wrapped youre script section use its body
+- no special onmount function, just add single queueMicrotask(f=>{}) https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#microtask-queuing
+js```
+<script>
+	//onload
+	queueMicrotask(f=>{
+		//onmount
+	})
+	$.dismount=e=> //ondismount	//for now only for root child (would be upgraded soon)
+</script>
+```
 ### $(selector)
+#### basic features even will work in &lt;style&gt; section
 - selector for querySelector method will replace .__ leading pattern by root className (.foo in example)
 - exact .__ selector will return this (rootElement) directly
+- [B] or [An+B] will replace to :nth-of-type(An+B) A is 0 as default
+- [-B] or [An-B] will replace to :nth-last-of-type(An+B) A is 0 as default
+#### advansed that work in $() and _click= (etc events) attribute bind
+- starting with '&lt;' selector will pass trailing string to parent jsx querySelector (eny times)
+- starting with '&gt;' selector will replace as :scope&gt; (Selectors Level 4)
+- trailing '$' will return jsx scope of finding element(s)
+- after '$' allowing to follow prop1.prop2...propN chain that will get this from jsx scope
+	- combining like '>$' will return all children array
+	- '<$' return the parrent jsx scope
+	- '<$emit' return parrent.emit prop - in can use for binding event from arrtibute, or emit from js
 ### $.toString()
 - return root component className.
 - It usefull for pass root component className to string representations (like template strings binding) by passing component scope
 ```js
 	`<div class=${$}__element_modificator>`
 //	<div class=block__element_modificator>
+```
+### $.removeChilds(element|elements[]|selector:String)
+- remove from jsx all elements[]=$(selector)
+- !Important if you whan remove jsx by selector you need to select it with trailing '$' or you remove only HTML elements
+- dont throwing Exception instead of this
+- return deleted elements[] or null if no one deleted (for youre self check)
+### $(undefined)
+- shortcut for upload new inserted class_=jsx.htm components
+```js
+//can use for cheepy inline adds like:
+$( this.insertAdjacentHTML('beforeend',`<div class=${$}__element_modificator></div>`) )
 ```
 ### $.log(tabs:Number)
 - can be used for log recursive tree of virtual element binded scope (children & methods)
@@ -67,6 +101,8 @@ You can force config const eventTypes to extend library by other native DOM even
 - click
 - change
 - dblclick
+### property getter
+- in all case getters of $.property descriptor will run once on binding
 ## self bind
 ```html
 <button _click=$method></button>
@@ -74,34 +110,35 @@ You can force config const eventTypes to extend library by other native DOM even
 	$.method=e=> //do something
 </script>
 ```
-## nested bind
+## nested bind child method
 ```html
 <button _click=.sub$method></button>
 <div _class=sub:subcomponent.htm></div>
 ```
 - click will call $.method of .sub element from subcomponent.htm &lt;script&gt; section
+## nested bind parrent method (emiting)
+```html
+<button _click=<$method></button>
+```
 # TODO Roadmap
 ## features
-- $('className[]') return childs[], :fisrt/last-of-type converts to [0/-1] child
-- $('className') return :fisrt-of-type
-- reuse $('className[]') in removeChild
 - bind with arguments (child constructor standart)
+- separete $() api to $ and $$ api for single multiple selects?
+	- $('className[]') return childs[], :fisrt/last-of-type converts to [0/-1] child
 - validate child by interface above _class
+	- by emiting
 ## fixes
-- element.removeChild(childElement) destruct $(childElement)
-- nested child bind infinite chain length (for now just self children)
 ## optimization
 - fetch cache (for now just browser/server chache somehow)
 
 ## moot features
 ```js
+$({}) //one pass set component scope
 f[Symbol.toStringTag] //detect async function binding (and then update)
 f=>Promise[] //runtime detect Promise or Promise[] for update when resolve
 
 $('beforeend',`<div _class=component></div>`) insertAdjacentHTML and $.update shortcut
-
-$({}) //one pass set component scope
-$('<div _class=component></div>') //capture exact load targets
-_class=component(args) //component constructor args
-_class=_{modificator}:component //argument reactive bind
+	$('<div _class=component></div>') //capture exact load targets
+		_class=component(args) //component constructor args
+		_class=_{modificator}:component //argument reactive bind
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsxldr",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jsxldr",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "devDependencies": {
         "live-server": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsxldr",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "tini jsx loader",
   "main": "index.html",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsxldr",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "tini jsx loader",
   "main": "index.html",
   "scripts": {

--- a/public/jsxldr.js
+++ b/public/jsxldr.js
@@ -1,9 +1,10 @@
 (function(){
-const nextId=0;
+let nextId=0;
 const map= {};    
 const parse=(BEM,str)=>str.replace(/((= |=|="|= ")|((^|\s)\.))((__[a-z])|__([^a-z]|$))/gi,`$2$3${BEM}$6$7`)
-    .replace(/\[((\d+)n|n(\d+))(\+\d+)?\]/g,`:nth-of-type($2$3n$4)`) //shortcut for :nth-of-type(An+B) by just [An+B] (or [nA+B] //linter fine form)
-    .replace(/\[((\d+)n|n(\d+))-(\d+)?\]/g,`:nth-last-of-type($2$3n+$4)`) //same for :nth-last-of-type(An+B) by [An-B]/[nA-B] (B must exist even if 0)
+    .replace(/\[(\d*)\]/,`[0n+$1]`).replace(/\[-(\d*)\]/,`[0n-$1]`)         //option for replace [A] / [-A] to [0n+A] / [0n-A]
+        .replace(/\[((\d+)n|n(\d+))(\+\d+)?\]/g,`:nth-of-type($2$3n$4)`)      //shortcut for :nth-of-type(An+B) by just [An+B] (or [nA+B] //linter fine form)
+        .replace(/\[((\d+)n|n(\d+))-(\d+)?\]/g,`:nth-last-of-type($2$3n+$4)`) //same for :nth-last-of-type(An+B) by [An-B]/[nA-B] (B must exist even if 0)
 const EVENT_TYPES=['_click','_dblclick','_change'];
 
 function jsxldr($pa, $pa_children){
@@ -14,24 +15,25 @@ function jsxldr($pa, $pa_children){
         let[,jsxClass,href,ext]=/(?:([^:]*):)?([^:]+?)(\.[^.]*)?$/.exec(jsxldrAttr)??[]
         jsxClass??=href; href+=ext??='.htm';
         if(!href || !jsxClass || /\./.test(jsxClass))return;
-        el.removeAttribute('_class'); el.classList.add(jsxClass); el.setAttribure('jsx',_id);
+        el.removeAttribute('_class'); el.classList.add(jsxClass); el.setAttribute('jsx',_id);
         const _children={};
         const $= Object.defineProperties(
             q=>{
                 if(q===undefined) return jsxldr.call(el,$,_children) //shortcut $() for refresh this
                 if(q=='.__')return el;                               //shortcut $('.__') for return this dom element
                 let[sel,scope]=q.split(/\$(?=[^\]]*$)/)
-                if(scope!=undefined){
-                    q+='[jsx]';
-                    scope= scope.split('.')
-                }
-                q= el.querySelectorAll(
-                    (jsxClass[0]=='>'?':scope':'')+       //shortcut for :scope> by starting with '>', without typing :scope
-                    parse(jsxClass,q)                     //replace '__' pattern in class literals to this jsxClass string
-                    //if after all finding $(prop(.prop(.prop(...)))) resolving dom nodes to scope object prop
-                )
+                console.log({sel,scope});
+                if(scope!=undefined)sel+='[jsx]';
+                if(sel[0]=='>')sel=':scope'+sel       //shortcut for :scope> by starting with '>', without typing :scope
+                q= parse(jsxClass,sel)            //replace '__' pattern in class literals to this jsxClass string
+
+                console.log(`${$}.querySelectorAll(${q})`);
+                q= [].slice.call(el.querySelectorAll(q))
+                console.log('=',q);
                 if(scope){
-                    q= q.flatMap(jsx=>{
+                    scope= scope.split('.')
+                    //if after all finding $(prop(.prop(.prop(...)))) resolving dom nodes to scope object prop
+                    q= [].flatmap.call(q,jsx=>{
                         jsx=jsx.getAttribute('jsx');
                         console.log({jsx});
                         if(jsx in map)return [map[jsx]]
@@ -44,29 +46,30 @@ function jsxldr($pa, $pa_children){
             parent:{value:$pa},            //TODO: JSX scope pa
             children:{value:BEM=> BEM? _children[BEM].slice(): _children},
             toString:{value:f=> jsxClass},
-            removeChild:{value:$ch=>{
-                console.log(`${$}.removeChild(${$ch})`,$ch);
-                if(typeof $ch=='string'){
-                    let ch= $($ch);
-                    if(!ch)return null
-                    else{
-                        let[...match]=ch.className.match(RegExp(Object.keys(_children).join('|') ));
-                        console.log({match});
-                        if(match.length>1)throw new Error("removeChild by ambiguous selector")
-                        if(match=match[0]){
-                            $ch = _children[match].find($ch => $ch('.__') === ch);
-                            if (!$ch) return null;
-                            let i = _children[$ch].indexOf($ch);
-                            _children[$ch].splice(i,1);
-                        }
-                        return el.removeChild(ch);
+            removeChild:{value:$chs=>{
+                console.log(`${$}.removeChild(${$chs})`,$chs);
+                if(typeof $chs=='string') $chs= $($chs);
+                console.log({$chs});
+                if(!$chs)return null;
+                $chs=[$chs].flat()    //support for removeChild([$ch1,$ch2,...,$chN]) same as removeChild($ch)
+                console.log({$chs});
+
+                let dels=$chs.flatMap($ch=>{
+                    if(typeof $ch=='function'){
+                        console.log('removing $ch()')
+                        let i = _children[$ch].indexOf($ch);
+                        if(!~i)return[];
+                        let id=$ch('.__').getAttribute('jsx');
+                        delete map[id];
+                        el.removeChild($ch('.__'));
+                        return _children[$ch].splice(i,1)
                     }
-                }else if(typeof $ch=='function'){
-                    let i = _children[$ch].indexOf($ch);
-                    if(!~i)return null;
-                    el.removeChild($ch('.__'));
-                    return _children[$ch].splice(i,1)[0];
-                }else return null
+                    console.log('removing ch',$ch, 'from parent', $ch.parentElement);
+                    try{return[$ch.parentElement.removeChild($ch)]}catch{return[]}
+                })
+                console.log({dels});
+                dels.map(del=>del.destruct?.());
+                return dels.length?dels:null
             }},
             tree:{value:(t,i)=>`${'\t'.repeat(t)}${$}[${i|0}]:{\n${[
                     ...Object.keys($).map(k => `${'\t'.repeat(-~t)}$${k}:${$[k]}`),
@@ -76,7 +79,7 @@ function jsxldr($pa, $pa_children){
                 ].join(`,${'\t'.repeat(t)}\n`)
             }}`},
         })
-        map[id]=$;
+        map[_id]=$;
         if($pa_children)$pa_children[$]=($pa_children[$]??[]).concat($)
 
         await fetch(href).then(r=>r.text()).then(async str=>{
@@ -95,8 +98,9 @@ function jsxldr($pa, $pa_children){
             //binds:
             bindlate.forEach(ch=>{
                 EVENT_TYPES.forEach(ev=>{
-                    let attr= ch.getAttribute(ev);
+                    let attr= ch.getAttribute(ev) ;
                     if(!attr)return;
+                    //TODO: by $ scope
                     let[v,sel,...bind]=/([.#$][^.#$]*)([.#$][^.#$]*)?([.#$][^.#$]*)?/.exec(attr)??[];
                     let $pa=$;
                     for(;v=bind.shift();sel=v) $pa= $pa.children(sel.slice(1) )[0];

--- a/public/jsxldr.js
+++ b/public/jsxldr.js
@@ -14,15 +14,21 @@ function jsxldr($pa, $pa_children){
         el.removeAttribute('_class'); el.classList.add(jsxClass);
         const _children={};
         const $= Object.defineProperties(
-            q=>
-                q===undefined?jsxldr.call(el,$,_children) //shortcut $() for refresh this
-                :q=='.__'?el                              //shortcut $('.__') for return this dom element
+            q=>{
+                if(q===undefined) return jsxldr.call(el,$,_children) //shortcut $() for refresh this
+                let[sel,scope]=q.split(/\$(?=[^\]]*$)/)
+                q= sel=='.__'?el                              //shortcut $('.__') for return this dom element
                 :el.querySelector(
                     (jsxClass[0]=='>'?':scope':'')+       //shortcut for :scope> by starting with '>', without typing :scope
                     parse(jsxClass,q)                     //replace '__' pattern in class literals to this jsxClass string
                     
                     //if after all finding $(prop(.prop(.prop(...)))) resolving dom nodes to scope object prop
                 )
+                if(scope!=undefined){
+                    
+                }
+                return q
+            }
             ,{
             parent:{value:$pa},            //TODO: JSX scope pa
             children:{value:BEM=> BEM? _children[BEM].slice(): _children},

--- a/public/polinome.htm
+++ b/public/polinome.htm
@@ -1,9 +1,11 @@
 <button class=__del _click=$del>-</button>
 <button class=__add _click=$add>+</button>
+
 <script>
-    $.add=e=> $.appendChild(`<div class=${$}__part><input value=0></div>`)
-    $.del=e=> (e = $('.__part:last-of-type') )? $.removeChild(e): $.parent.del(this)
+    $.add=e=> $( this.insertAdjacentHTML('beforeend',`<div class=${$}__part><input value=0></div>`) )
+    $.del=e=> $.removeChild('.__part:last-of-type') || $.parent.del($)
 </script>
+
 <style>
     .__{counter-reset:section -1;text-align:right;min-height:1em}
     .__part, .__add, .__del{display:inline;float:right;margin:0 .25em}

--- a/public/polinome.htm
+++ b/public/polinome.htm
@@ -3,7 +3,7 @@
 
 <script>
     $.add=e=> $( this.insertAdjacentHTML('beforeend',`<div class=${$}__part><input value=0></div>`) )
-    $.del=e=> $.removeChild('.__part:last-of-type') || $.parent.del($)
+    $.del=e=> $.removeChild('.__part[-1]') || $.parent.del($)
 </script>
 
 <style>

--- a/public/polinome.htm
+++ b/public/polinome.htm
@@ -3,7 +3,8 @@
 
 <script>
     $.add=e=> $( this.insertAdjacentHTML('beforeend',`<div class=${$}__part><input value=0></div>`) )
-    $.del=e=> $.removeChild('.__part[-1]') || $.parent.del($)
+    $.del=e=> $.removeChilds('.__part[-1]') || $.parent.del($)
+    $.dismount=e=>alert('polinome.dismount called')
 </script>
 
 <style>

--- a/public/polycalc.htm
+++ b/public/polycalc.htm
@@ -2,6 +2,9 @@
     <button class=__log _click=$log>=</button>
     <button class=__add _click=.polylist$add>+</button>
     <button class=__del _click=.polylist$del>-</button>
+<!--    <button class=__update _click=polylist$update>↻</button>-->
+    <span class="__rtc">{bind_value}</span>
+<!--    <span class="__rtc"><x></x></span>-->
     <input _change=.polylist$change placeholder="input subjsx.background" />
 </div>
 <div _class=polylist></div>
@@ -16,4 +19,8 @@
 
 <script>
     $.log=e=> console.log($.tree())
+    $.emitFromChild=e=>{
+        console.log(e)
+        alert('emitFromChild() fas been fired')
+    }
 </script>

--- a/public/polycalc.htm
+++ b/public/polycalc.htm
@@ -1,6 +1,6 @@
 <div class=header>header:
     <button class=__log _click=$log>=</button>
-    <button class=__add _click=":scope>.polylist$add">+</button>
+    <button class=__add _click=.polylist$add>+</button>
     <button class=__del _click=.polylist$del>-</button>
     <input _change=.polylist$change placeholder="input subjsx.background" />
 </div>

--- a/public/polycalc.htm
+++ b/public/polycalc.htm
@@ -1,11 +1,12 @@
 <div class=header>header:
+    <button class=__log _click=$log>=</button>
     <button class=__add _click=.polylist$add>+</button>
     <button class=__del _click=.polylist$del>-</button>
+    <input _change=.polylist$change placeholder="input subjsx.background" />
 </div>
 <div _class=polylist></div>
-<div class=footer _dblclick=.polylist$clear>footer:
-</div>
-    <input _change=.polylist$change placeholder=input sub.background />
+<div class=footer _dblclick=.polylist$clear>footer:<sub>dblclick me to clear list...</sub></div>
+
 <style>
     .header,.footer{
         background:#def;
@@ -14,5 +15,5 @@
 </style>
 
 <script>
-    //this component use nested bindings for extend functionality from polylist.htm
+    $.log=e=> console.log($.tree())
 </script>

--- a/public/polycalc.htm
+++ b/public/polycalc.htm
@@ -1,6 +1,6 @@
 <div class=header>header:
     <button class=__log _click=$log>=</button>
-    <button class=__add _click=.polylist$add>+</button>
+    <button class=__add _click=":scope>.polylist$add">+</button>
     <button class=__del _click=.polylist$del>-</button>
     <input _change=.polylist$change placeholder="input subjsx.background" />
 </div>

--- a/public/polylist.htm
+++ b/public/polylist.htm
@@ -3,14 +3,12 @@
 <div class=___mod3>___mod3</div>
 <script>
     $.add=e=> $( this.insertAdjacentHTML('beforeend',`<div _class=polinome></div>`) )
-    $.del=$ch=> $.removeChild($ch) || $.removeChild('.polinome:last-of-type')
+    $.del=$ch=> $.removeChild($ch) || $.removeChild('>[-1]$') //selfchild nth-last-of-type(0n+1) jsx
     $.change=e=> this.style.background= e.target.value
-    $.clear=e=> $.children('polinome').forEach($.removeChild)
-
-    $.clear2=e=> $.removeChild('>.polinome$')
+    $.clear=e=> $.removeChild('>$') //selfchild (every) jsx
     //$('>.polinome:nth-of-type(2n+1)$style.background')='#eee';
     //$('>.polinome[2n+1].style.background')='#eee';
-    //$('>*$')
+    //$('>*')
     queueMicrotask(f=>{ //queueMicrotask can natively simulate synchronous onmount component stage
         $.add(), $.add(), $.add();
     })
@@ -23,7 +21,6 @@
     }
     .polinome[n2+1]{background:#eee}
     .polinome[n2]{background:#ecf}
-    
     .polinome[n0-1]{background:#cfc}
 
     .__::before{color:red;content:'.__::before'}

--- a/public/polylist.htm
+++ b/public/polylist.htm
@@ -1,10 +1,16 @@
-<div _class=polinome></div>
+<div class=_mod1>_mod1</div>
+<div class=__element2>__element2</div>
+<div class=___mod3>___mod3</div>
 <script>
     $.add=e=> $( this.insertAdjacentHTML('beforeend',`<div _class=polinome></div>`) )
     $.del=$ch=> $.removeChild($ch) || $.removeChild('.polinome:last-of-type')
     $.change=e=> this.style.background= e.target.value
     $.clear=e=> $.children('polinome').forEach($.removeChild)
 
+    $.clear2=e=> $.removeChild('>.polinome$')
+    //$('>.polinome:nth-of-type(2n+1)$style.background')='#eee';
+    //$('>.polinome[2n+1].style.background')='#eee';
+    
     queueMicrotask(f=>{ //queueMicrotask can natively simulate synchronous onmount component stage
         $.add(), $.add(), $.add();
     })
@@ -15,4 +21,14 @@
         padding:1em;
         border-bottom: 1px solid gray;
     }
+    .polinome[n2+1]{background:#eee}
+    .polinome[n2]{background:#ecf}
+    
+    .polinome[n0-1]{background:#cfc}
+
+    .__::before{color:red;content:'.__::before'}
+    ._mod1::before{color:red;content:'._mod1::before'}
+    .__element2::before{content:'.__element2::before';color:red}
+    .___mod3::before{content:'.___mod3::before';color:red}
+
 </style>

--- a/public/polylist.htm
+++ b/public/polylist.htm
@@ -1,17 +1,17 @@
+<button class="__emiter" _click=<$emitFromChild><$emitFromChild</button>
+
 <div class=_mod1>_mod1</div>
-<div class=__element2>__element2</div>
+<div class=__element2>__element2 emitFromChild</div>
 <div class=___mod3>___mod3</div>
 <script>
     $.add=e=> $( this.insertAdjacentHTML('beforeend',`<div _class=polinome></div>`) )
-    $.del=$ch=> $.removeChild($ch) || $.removeChild('>[-1]$') //selfchild nth-last-of-type(0n+1) jsx
+    $.del=$ch=> $.removeChilds($ch) || $.removeChilds('>[-1]$') //selfchild nth-last-of-type(0n+1) jsx
     $.change=e=> this.style.background= e.target.value
-    $.clear=e=> $.removeChild('>$') //selfchild (every) jsx
-    //$('>.polinome:nth-of-type(2n+1)$style.background')='#eee';
-    //$('>.polinome[2n+1].style.background')='#eee';
-    //$('>*')
+    $.clear=e=> $.removeChilds('>$') //selfchild (every) jsx
     queueMicrotask(f=>{ //queueMicrotask can natively simulate synchronous onmount component stage
         $.add(), $.add(), $.add();
     })
+    $.dismount=e=>alert('polylist.dismount called')
 </script>
 
 <style>
@@ -24,7 +24,7 @@
     .polinome[n0-1]{background:#cfc}
 
     .__::before{color:red;content:'.__::before'}
-    ._mod1::before{color:red;content:'._mod1::before'}
+    ._mod1::before{color:red;content:'._mod1::before (dont rewrite! single lodash class)'}
     .__element2::before{content:'.__element2::before';color:red}
     .___mod3::before{content:'.___mod3::before';color:red}
 

--- a/public/polylist.htm
+++ b/public/polylist.htm
@@ -1,13 +1,15 @@
+<div _class=polinome></div>
 <script>
-    $.add=e=> $.appendChild(`<div _class=polinome></div>`)
-    $.del=e=> e instanceof Element? $.removeChild(e): $.removeChild( $('.polinome:last-of-type') )
-    $.clear=e=> this.querySelectorAll('.polinome').forEach($.removeChild)
+    $.add=e=> $( this.insertAdjacentHTML('beforeend',`<div _class=polinome></div>`) )
+    $.del=$ch=> $.removeChild($ch) || $.removeChild('.polinome:last-of-type')
     $.change=e=> this.style.background= e.target.value
+    $.clear=e=> $.children('polinome').forEach($.removeChild)
 
     queueMicrotask(f=>{ //queueMicrotask can natively simulate synchronous onmount component stage
         $.add(), $.add(), $.add();
     })
 </script>
+
 <style>
     .polinome{
         padding:1em;

--- a/public/polylist.htm
+++ b/public/polylist.htm
@@ -10,7 +10,7 @@
     $.clear2=e=> $.removeChild('>.polinome$')
     //$('>.polinome:nth-of-type(2n+1)$style.background')='#eee';
     //$('>.polinome[2n+1].style.background')='#eee';
-    
+    //$('>*$')
     queueMicrotask(f=>{ //queueMicrotask can natively simulate synchronous onmount component stage
         $.add(), $.add(), $.add();
     })


### PR DESCRIPTION
scope access child/parent/their props worked
for binds too
css shortcuts for :scope
for [An+B] to :nth-of-type(An+B) and their forms
$.dismount autocall on jsx removeChilds
(for root removing jsx for now)